### PR TITLE
fix crc32_iscsi_base algo

### DIFF
--- a/crc/crc_base.c
+++ b/crc/crc_base.c
@@ -108,12 +108,12 @@ unsigned int crc32_iscsi_base(unsigned char *buffer, int len, unsigned int crc_i
 	p_buf = (unsigned char *)buffer;
 	unsigned char *p_end = buffer + len;
 
-	crc = crc_init;
+	crc = ~crc_init;
 
 	while (p_buf < (unsigned char *)p_end) {
 		crc = (crc >> 8) ^ crc32_table_iscsi_base[(crc & 0x000000FF) ^ *p_buf++];
 	}
-	return crc;
+	return ~crc;
 }
 
 // crc16_t10dif baseline function


### PR DESCRIPTION
Before this patch completely 0-filled buffers would always result in 0.

The fix for this patch was inspired on the standard Golang crc32 algo as found here:
https://github.com/golang/go/blob/master/src/hash/crc32/crc32_generic.go#L40-L48

As you can see, the algo is more or less the same, except the negating part, which is what this patch attempts to fix. This does mean that all crc's generated by this function are now different. If backwards compatibility is therefore an issue, we could perhaps move that to a new function instead?