### PR TITLE
build: fix compilation with CPU not supporting SSE

### DIFF
--- a/erasure_code/ec_highlevel_func.c
+++ b/erasure_code/ec_highlevel_func.c
@@ -30,6 +30,7 @@
 #include "erasure_code.h"
 #include "types.h"
 
+#if __x86_64__  || __i386__ || _M_X64 || _M_IX86
 void ec_encode_data_sse(int len, int k, int rows, unsigned char *g_tbls, unsigned char **data,
 			unsigned char **coding)
 {
@@ -320,6 +321,7 @@ void ec_encode_data_update_avx2(int len, int k, int rows, int vec_i, unsigned ch
 }
 
 #endif //__WORDSIZE == 64 || _WIN64 || __x86_64__
+#endif //__x86_64__  || __i386__ || _M_X64 || _M_IX86
 
 struct slver {
 	UINT16 snum;

--- a/erasure_code/gf_vect_mad_perf.c
+++ b/erasure_code/gf_vect_mad_perf.c
@@ -34,11 +34,17 @@
 #include "types.h"
 #include "test.h"
 
-//By default, test sse version
 #ifndef FUNCTION_UNDER_TEST
+//By default, test sse version
+#if __x86_64__  || __i386__ || _M_X64 || _M_IX86
 # define FUNCTION_UNDER_TEST gf_4vect_mad_sse
 # define REF_FUNCTION gf_4vect_dot_prod_sse
 # define VECT 4
+#else
+# define FUNCTION_UNDER_TEST gf_vect_mad_base
+# define REF_FUNCTION gf_vect_dot_prod_base
+# define VECT 1
+#endif //__x86_64__  || __i386__ || _M_X64 || _M_IX86
 #endif
 
 #define str(s) #s

--- a/erasure_code/gf_vect_mad_test.c
+++ b/erasure_code/gf_vect_mad_test.c
@@ -37,11 +37,17 @@
 # define ALIGN_SIZE 16
 #endif
 
-//By default, test sse version
 #ifndef FUNCTION_UNDER_TEST
+#if __x86_64__  || __i386__ || _M_X64 || _M_IX86
+//By default, test sse version
 # define FUNCTION_UNDER_TEST gf_6vect_mad_sse
 # define REF_FUNCTION gf_6vect_dot_prod_sse
 # define VECT 6
+#else
+# define FUNCTION_UNDER_TEST gf_vect_mad_base
+# define REF_FUNCTION gf_vect_dot_prod_base
+# define VECT 1
+#endif //__x86_64__  || __i386__ || _M_X64 || _M_IX86
 #endif
 
 #ifndef TEST_MIN_SIZE

--- a/igzip/encode_df.c
+++ b/igzip/encode_df.c
@@ -4,11 +4,13 @@
 #include <memory.h>
 #include <assert.h>
 
+#if __x86_64__  || __i386__ || _M_X64 || _M_IX86
 #ifdef _MSC_VER
 # include <intrin.h>
 #else
 # include <x86intrin.h>
 #endif
+#endif //__x86_64__  || __i386__ || _M_X64 || _M_IX86
 
 #include "encode_df.h"
 #include "bitbuf2.h"

--- a/igzip/huff_codes.c
+++ b/igzip/huff_codes.c
@@ -27,14 +27,8 @@
   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 **********************************************************************/
 
-#include <immintrin.h>
-#include <stdint.h>
-#include <string.h>
-#include <assert.h>
-#include "igzip_lib.h"
 #include "huff_codes.h"
 #include "huffman.h"
-#include "bitbuf2.h"
 #include "flatten_ll.h"
 
 /* The order code length codes are written in the dynamic code header. This is

--- a/igzip/huff_codes.h
+++ b/igzip/huff_codes.h
@@ -30,18 +30,20 @@
 #ifndef HUFF_CODES_H
 #define HUFF_CODES_H
 
-#include <immintrin.h>
 #include <stdint.h>
 #include <string.h>
 #include <assert.h>
 #include "igzip_lib.h"
 #include "bitbuf2.h"
 
+#if __x86_64__  || __i386__ || _M_X64 || _M_IX86
+# include <immintrin.h>
 #ifdef _MSC_VER
 # include <intrin.h>
 #else
 # include <x86intrin.h>
 #endif
+#endif //__x86_64__  || __i386__ || _M_X64 || _M_IX86
 
 #define LIT_LEN ISAL_DEF_LIT_LEN_SYMBOLS
 #define DIST_LEN ISAL_DEF_DIST_SYMBOLS

--- a/igzip/huffman.h
+++ b/igzip/huffman.h
@@ -32,12 +32,16 @@
 #include <assert.h>
 #include "igzip_lib.h"
 
+#if __x86_64__  || __i386__ || _M_X64 || _M_IX86
 #ifdef _MSC_VER
 # include <intrin.h>
 # define inline __inline
 #else
 # include <x86intrin.h>
 #endif
+#else
+# define inline __inline
+#endif //__x86_64__  || __i386__ || _M_X64 || _M_IX86
 
 static inline uint32_t bsr(uint32_t val)
 {


### PR DESCRIPTION
This patch makes the project compile and run (tests and
performance tests as well) with CPUs which are not
supporting SSE instructions.

New patch will follow later in a new pull request to add
native power8/9 support on erasure codes. 