### PR TITLE
igzip: fix build failure for CPUs with BMI capability

### DIFF
--- a/igzip/huffman.h
+++ b/igzip/huffman.h
@@ -64,9 +64,7 @@ static inline uint32_t tzcnt(uint64_t val)
 	cnt = cnt / 8;
 #elif defined(__x86_64__)
 
-	cnt = __bsfq(val);
-	if(val == 0)
-		cnt = 64;
+	cnt = (val == 0)? 64 : __builtin_ctzll(val);
 	cnt = cnt / 8;
 
 #else

--- a/igzip/huffman.h
+++ b/igzip/huffman.h
@@ -62,7 +62,7 @@ static inline uint32_t tzcnt(uint64_t val)
 #ifdef __BMI__
 	cnt = __tzcnt_u64(val);
 	cnt = cnt / 8;
-#elifdef __x86_64__
+#elif defined(__x86_64__)
 
 	cnt = __bsfq(val);
 	if(val == 0)


### PR DESCRIPTION
…also makes use of an optimized algorithm for x86_64 CPUs without the BMI.

Signed-off-by: Konstantin Kharlamov <Hi-Angel@yandex.ru>