### PR TITLE
Exclude AVX512 files for non-support cases

### DIFF
--- a/erasure_code/Makefile.am
+++ b/erasure_code/Makefile.am
@@ -73,7 +73,7 @@ lsrc_x86_64  += \
 		erasure_code/gf_6vect_mad_avx2.asm \
 		erasure_code/ec_multibinary.asm
 
-#if HAVE_AVX512
+if WITH_AVX512
 lsrc_x86_64  += \
 		erasure_code/gf_vect_dot_prod_avx512.asm \
 		erasure_code/gf_2vect_dot_prod_avx512.asm \
@@ -83,6 +83,7 @@ lsrc_x86_64  += \
 		erasure_code/gf_2vect_mad_avx512.asm \
 		erasure_code/gf_3vect_mad_avx512.asm \
 		erasure_code/gf_4vect_mad_avx512.asm
+endif
 
 lsrc_x86_32  += \
 		erasure_code/ec_highlevel_func.c \

--- a/raid/Makefile.am
+++ b/raid/Makefile.am
@@ -39,9 +39,13 @@ lsrc_x86_64 += \
 		raid/pq_gen_avx.asm \
 		raid/xor_gen_avx.asm \
 		raid/pq_gen_avx2.asm \
-		raid/xor_gen_avx512.asm \
-		raid/pq_gen_avx512.asm \
 		raid/raid_multibinary.asm
+
+if WITH_AVX512
+lsrc_x86_64 += \
+		raid/xor_gen_avx512.asm \
+		raid/pq_gen_avx512.asm
+endif
 
 lsrc_x86_32 += \
 		raid/xor_gen_sse.asm \


### PR DESCRIPTION
When AVX512 is not supported, all .asm files requiring AVX512 should not be included in the list lsrc