### PR TITLE
build: Fix autoconf for non-x86 arch

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -163,6 +163,12 @@ if test x"$is_x86" = x"yes"; then
   AC_SUBST([yasm_args])
   AM_CONDITIONAL(DARWIN, test x"$arch" = x"darwin")
   AC_MSG_RESULT([Using $AS args target "$arch" "$yasm_args"])
+else
+  # Disable below conditionals if not x86
+  AM_CONDITIONAL(USE_YASM, test "x" = "y")
+  AM_CONDITIONAL(USE_NASM, test "x" = "y")
+  AM_CONDITIONAL(WITH_AVX512, test "x" = "y")
+  AM_CONDITIONAL(DARWIN, test "x" = "y")
 fi
 
 


### PR DESCRIPTION
Due to latest changes to configure.ac, some conditional variables are
now only defined for x86, which leads to building errors on non-x86
arch: 'configure: error: conditional "USE_YASM" was never defined'

Change-Id: If6dbd23c6898e04f4755d713b1e76e2b5fc34232
Signed-off-by: Yibo Cai <yibo.cai@arm.com>