### PR TITLE
aarch64: Fix dynamic lib call crash

### DIFF
--- a/include/multibinary_arm.h
+++ b/include/multibinary_arm.h
@@ -36,6 +36,8 @@
 
 	.text
 	.global \name
+	.type \name, %function
+
 	\name\():
 		adrp	x9, \name\()_dispatched
 		ldr	x10, [x9, :lo12:\name\()_dispatched]

--- a/mem/aarch64/mem_zero_detect_neon.S
+++ b/mem/aarch64/mem_zero_detect_neon.S
@@ -37,6 +37,7 @@
 // output: -> x0 (true or false)
 
 .global mem_zero_detect_neon
+.type mem_zero_detect_neon, %function
 
 mem_zero_detect_neon:
 	cmp	x1, #(16*24-1)

--- a/raid/aarch64/pq_check_neon.S
+++ b/raid/aarch64/pq_check_neon.S
@@ -30,6 +30,7 @@
 .text
 
 .global pq_check_neon
+.type pq_check_neon, %function
 
 /* int pq_check_neon(int vects, int len, void **src) */
 

--- a/raid/aarch64/pq_gen_neon.S
+++ b/raid/aarch64/pq_gen_neon.S
@@ -30,6 +30,7 @@
 .text
 
 .global pq_gen_neon
+.type pq_gen_neon, %function
 
 /* int pq_gen_neon(int vects, int len, void **src) */
 

--- a/raid/aarch64/xor_check_neon.S
+++ b/raid/aarch64/xor_check_neon.S
@@ -30,6 +30,7 @@
 .text
 
 .global xor_check_neon
+.type xor_check_neon, %function
 
 /* int xor_check_neon(int vects, int len, void **src) */
 

--- a/raid/aarch64/xor_gen_neon.S
+++ b/raid/aarch64/xor_gen_neon.S
@@ -30,6 +30,7 @@
 .text
 
 .global xor_gen_neon
+.type xor_gen_neon, %function
 
 /* int xor_gen_neon(int vects, int len, void **src) */
 


### PR DESCRIPTION
If an application treats these functions as function pointers, and this
lib (isa-l) is compiled into solib, a segmentation fault may occur.

For example: Ubuntu 16.04 on arm64 platfrom will be crash, because the
linker does not know that this symbol is a function, so mark the function
type explicitly with %function to solves this issue.

Change-Id: Iba41b1f1367146d7dcce09203694b08b1cb8ec20
Signed-off-by: Zhiyuan Zhu <zhiyuan.zhu@arm.com>