### PR TITLE
aarch64: Cleanup build issues

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -19,6 +19,9 @@ unit_tests_extra=
 perf_tests_extra=
 examples=
 other_tests=
+other_tests_x86_64=
+other_tests_x86_32=
+other_tests_aarch64=
 lsrc_x86_64=
 lsrc_x86_32=
 lsrc_aarch64=
@@ -50,14 +53,17 @@ libisal_la_SOURCES = ${lsrc}
 
 if CPU_X86_64
 libisal_la_SOURCES += ${lsrc_x86_64}
+other_tests += ${other_tests_x86_64}
 endif
 
 if CPU_X86_32
 libisal_la_SOURCES += ${lsrc_x86_32}
+other_tests += ${other_tests_x86_32}
 endif
 
 if CPU_AARCH64
 libisal_la_SOURCES += ${lsrc_aarch64}
+other_tests += ${other_tests_aarch64}
 endif
 
 if CPU_UNDEFINED

--- a/erasure_code/Makefile.am
+++ b/erasure_code/Makefile.am
@@ -141,8 +141,16 @@ perf_tests   += erasure_code/gf_vect_mul_perf \
 		erasure_code/erasure_code_base_perf \
 		erasure_code/erasure_code_update_perf
 
-other_tests  += \
-		erasure_code/gen_rs_matrix_limits \
+other_tests  += erasure_code/gen_rs_matrix_limits
+
+other_tests_x86_64 += \
+		erasure_code/gf_2vect_dot_prod_sse_test \
+		erasure_code/gf_3vect_dot_prod_sse_test \
+		erasure_code/gf_4vect_dot_prod_sse_test \
+		erasure_code/gf_5vect_dot_prod_sse_test \
+		erasure_code/gf_6vect_dot_prod_sse_test
+
+other_tests_x86_32 += \
 		erasure_code/gf_2vect_dot_prod_sse_test \
 		erasure_code/gf_3vect_dot_prod_sse_test \
 		erasure_code/gf_4vect_dot_prod_sse_test \

--- a/igzip/generate_custom_hufftables.c
+++ b/igzip/generate_custom_hufftables.c
@@ -266,8 +266,7 @@ int main(int argc, char *argv[])
 			fclose(file);
 			return 1;
 		}
-		fread(stream, 1, file_length, file);
-		if (ferror(file)) {
+		if (fread(stream, 1, file_length, file) != file_length) {
 			printf("Error occurred when reading file");
 			fclose(file);
 			free(stream);

--- a/igzip/igzip_inflate_test.c
+++ b/igzip/igzip_inflate_test.c
@@ -30,6 +30,7 @@
 #define _FILE_OFFSET_BITS 64
 #include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <zlib.h>
 #include "igzip_lib.h"
 #include "huff_codes.h"

--- a/igzip/igzip_perf.c
+++ b/igzip/igzip_perf.c
@@ -29,6 +29,7 @@
 
 #define _FILE_OFFSET_BITS 64
 #include <stdio.h>
+#include <stdlib.h>
 #include <assert.h>
 #include <getopt.h>
 #include "huff_codes.h"

--- a/igzip/igzip_rand_test.c
+++ b/igzip/igzip_rand_test.c
@@ -2644,7 +2644,11 @@ int test_compress_file(char *file_name)
 			printf("Failed to allocate in_buf for test_compress_file\n");
 			return MALLOC_FAILED;
 		}
-		fread(in_buf, 1, in_size, in_file);
+		if (fread(in_buf, 1, in_size, in_file) != in_size) {
+			printf("Failed to read in_buf from test_compress_file\n");
+			free(in_buf);
+			return FILE_READ_FAILED;
+		}
 	}
 
 	ret |= test_compress_stateless(in_buf, in_size, NO_FLUSH);
@@ -2702,9 +2706,7 @@ int create_custom_hufftables(struct isal_hufftables *hufftables_custom, int file
 			}
 		}
 
-		fread(stream, 1, file_length, file);
-
-		if (ferror(file)) {
+		if (fread(stream, 1, file_length, file) != file_length) {
 			printf("Error occurred when reading file\n");
 			fclose(file);
 			free(stream);

--- a/include/multibinary_arm.h
+++ b/include/multibinary_arm.h
@@ -44,8 +44,8 @@
 		br	x10
 	\name\()_dispatch_init:
 		add	x9, x9, :lo12:\name\()_dispatched
-		adrp	x10, \func_neon
-		add	x10, x10, :lo12:\func_neon
+		adrp	x10, :got:\func_neon
+		ldr	x10, [x10, :got_lo12:\func_neon]
 		str	x10, [x9]
 		br	x10
 .endm
@@ -69,8 +69,8 @@ xor_gen:
 
 xor_gen_dispatch_init:
 	add	x9, x9, :lo12:xor_gen_dispatched
-	adrp	x10, xor_gen_neon
-	add	x10, x10, :lo12:xor_gen_neon
+	adrp	x10, :got:xor_gen_neon
+	ldr	x10, [x10, :got_lo12:xor_gen_neon]
 	str	x10, [x9]
 	br	x10
 #endif

--- a/make.inc
+++ b/make.inc
@@ -102,6 +102,8 @@ ARFLAGS  = $(ARFLAGS_$(arch))
 DEFINES += $(addprefix -D , $D)
 CLEANFILES += $(O) *.o *.a $(all_tests) $(bin_PROGRAMS) $(lib_name) $(so_lib_name) $(all_llvm_fuzz_tests)
 
+other_tests += $(other_tests_$(host_cpu))
+
 lsrc += $(lsrc_$(host_cpu))
 O = bin
 lobj  += $(patsubst %.c,%.o,$(patsubst %.S,%.o,$(patsubst %.asm,%.o,$(lsrc) $(lsrc_intrinsic))))

--- a/programs/igzip_cli.c
+++ b/programs/igzip_cli.c
@@ -304,7 +304,7 @@ void *malloc_safe(size_t size)
 FILE *fopen_safe(char *file_name, char *mode)
 {
 	FILE *file;
-	char answer = 0, tmp;
+	int answer = 0, tmp;
 
 	/* Assumes write mode always starts with w */
 	if (mode[0] == 'w') {

--- a/tests/fuzz/igzip_fuzz_inflate.c
+++ b/tests/fuzz/igzip_fuzz_inflate.c
@@ -1,5 +1,6 @@
 #define _FILE_OFFSET_BITS 64
 #include <stdio.h>
+#include <stdlib.h>
 #include <assert.h>
 #include <zlib.h>
 #include "huff_codes.h"
@@ -31,7 +32,10 @@ int main(int argc, char *argv[])
 		exit(1);
 	}
 
-	fread(in_buf, 1, in_file_size, in);
+	if (fread(in_buf, 1, in_file_size, in) != in_file_size) {
+		fprintf(stderr, "Failed to read from %s\n", argv[1]);
+		exit(1);
+	}
 
 	return LLVMFuzzerTestOneInput(in_buf, in_file_size);
 }


### PR DESCRIPTION
This patch addresses one build failure and fixes several build warnings
for Arm (some for x86 too).

- Fix dynamic relocation link failure of ld.bfd 2.30 on Arm
  [log] relocation R_AARCH64_ADR_PREL_PG_HI21 against symbol `xor_gen_neon' which may bind externally can not be used when making a shared object

- Add arch dependent "other_tests" to exclude x86 specific tests on Arm
  [log] isa-l/erasure_code/gf_2vect_dot_prod_sse_test.c:181: undefined reference to `gf_2vect_dot_prod_sse'

- Check "fread" return value to fix gcc warnings on Arm and x86
  [log] warning: ignoring return value of ‘fread’, declared with attribute warn_unused_result [-Wunused-result]
        fread(in_buf, 1, in_size, in_file);
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

- Fix issue of comparing "char" with "int" on Arm. "char" is unsigned
  on Arm by default, an unsigned char will never equal to EOF(-1).
  [Log] programs/igzip_cli.c:318:31: warning: comparison is always true due to limited range of data type [-Wtype-limits]
        while (tmp != '\n' && tmp != EOF)
                                  ^~

- Include <stdlib.h> to several files to fix build warnings on Arm
  [log] igzip/igzip_inflate_perf.c:339:5: warning: incompatible implicit declaration of built-in function ‘exit’
        exit(0);
        ^~~~

Change-Id: I82c1b63316b634b3d398ffba2ff815679d9051a8
Signed-off-by: Yibo Cai <yibo.cai@arm.com>